### PR TITLE
ci: dart formatの多層防御を導入（Hooks + CI）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "FILE_PATH=$(jq -r '.tool_input.file_path') && if [[ \"$FILE_PATH\" == *.dart ]]; then devcontainer exec --workspace-folder /Users/masaki/Documents/training-app dart format \"$FILE_PATH\"; fi"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,9 @@ jobs:
     - name: Install dependencies
       run: flutter pub get
 
+    - name: Check formatting
+      run: dart format --output=none --set-exit-if-changed .
+
     - name: Analyze project
       run: flutter analyze
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,4 @@
 include: package:flutter_lints/flutter.yaml
+
+formatter:
+  page_width: 80

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,7 +46,9 @@ class MainApp extends StatelessWidget {
             ),
             backgroundColor: WidgetStateProperty.all(Colors.blueAccent),
             foregroundColor: WidgetStateProperty.all(Colors.white),
-            padding: WidgetStateProperty.all(const EdgeInsets.symmetric(vertical: 16)),
+            padding: WidgetStateProperty.all(
+              const EdgeInsets.symmetric(vertical: 16),
+            ),
             textStyle: WidgetStateProperty.all(
               const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
             ),

--- a/lib/repositories/training_repository.dart
+++ b/lib/repositories/training_repository.dart
@@ -52,7 +52,6 @@ class TrainingRepository {
     return _box.values.where((record) {
       return record.date.isAfter(startDate.subtract(const Duration(days: 1))) &&
           record.date.isBefore(endDate.add(const Duration(days: 1)));
-    }).toList()
-      ..sort((a, b) => b.date.compareTo(a.date));
+    }).toList()..sort((a, b) => b.date.compareTo(a.date));
   }
 }

--- a/lib/screens/training_record_card.dart
+++ b/lib/screens/training_record_card.dart
@@ -20,9 +20,7 @@ class TrainingRecordCard extends StatelessWidget {
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
       elevation: 1,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(14),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
       child: InkWell(
         borderRadius: BorderRadius.circular(14),
         onTap: onTap,
@@ -32,13 +30,11 @@ class TrainingRecordCard extends StatelessWidget {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               CircleAvatar(
-                backgroundColor:
-                    Theme.of(context).colorScheme.primaryContainer,
+                backgroundColor: Theme.of(context).colorScheme.primaryContainer,
                 child: Icon(
                   Icons.fitness_center,
                   size: 20,
-                  color:
-                      Theme.of(context).colorScheme.onPrimaryContainer,
+                  color: Theme.of(context).colorScheme.onPrimaryContainer,
                 ),
               ),
               const SizedBox(width: 12),
@@ -91,8 +87,7 @@ class TrainingRecordCard extends StatelessWidget {
                       vertical: 4,
                     ),
                     decoration: BoxDecoration(
-                      color:
-                          Theme.of(context).colorScheme.primaryContainer,
+                      color: Theme.of(context).colorScheme.primaryContainer,
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Text(
@@ -100,17 +95,12 @@ class TrainingRecordCard extends StatelessWidget {
                       style: TextStyle(
                         fontWeight: FontWeight.bold,
                         fontSize: 13,
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onPrimaryContainer,
+                        color: Theme.of(context).colorScheme.onPrimaryContainer,
                       ),
                     ),
                   ),
                   const SizedBox(height: 8),
-                  Icon(
-                    Icons.chevron_right,
-                    color: Colors.grey.shade400,
-                  ),
+                  Icon(Icons.chevron_right, color: Colors.grey.shade400),
                 ],
               ),
             ],
@@ -126,10 +116,7 @@ class TrainingRecordCard extends StatelessWidget {
       children: [
         Icon(icon, size: 14, color: Colors.grey.shade500),
         const SizedBox(width: 3),
-        Text(
-          text,
-          style: TextStyle(color: Colors.grey.shade600, fontSize: 12),
-        ),
+        Text(text, style: TextStyle(color: Colors.grey.shade600, fontSize: 12)),
       ],
     );
   }

--- a/lib/screens/training_record_detail_dialog.dart
+++ b/lib/screens/training_record_detail_dialog.dart
@@ -5,7 +5,10 @@ import '../repositories/repository_provider.dart';
 import 'detail_dialog_result.dart';
 
 /// 戻り値: DetailDialogResult.edit なら編集要求、DetailDialogResult.delete なら削除済み、null はそれ以外
-Future<DetailDialogResult?> showRecordDetailDialog(BuildContext context, TrainingRecord record) {
+Future<DetailDialogResult?> showRecordDetailDialog(
+  BuildContext context,
+  TrainingRecord record,
+) {
   final scaffoldMessenger = ScaffoldMessenger.of(context);
   return showDialog<DetailDialogResult>(
     context: context,
@@ -16,132 +19,133 @@ Future<DetailDialogResult?> showRecordDetailDialog(BuildContext context, Trainin
         child: Padding(
           padding: const EdgeInsets.all(24),
           child: SingleChildScrollView(
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Container(
-                    padding: const EdgeInsets.symmetric(
-                      horizontal: 10,
-                      vertical: 4,
-                    ),
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.primaryContainer,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Text(
-                      record.formattedDate,
-                      style: TextStyle(
-                        fontWeight: FontWeight.bold,
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onPrimaryContainer,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 4,
+                      ),
+                      decoration: BoxDecoration(
+                        color: Theme.of(context).colorScheme.primaryContainer,
+                        borderRadius: BorderRadius.circular(8),
+                      ),
+                      child: Text(
+                        record.formattedDate,
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: Theme.of(
+                            context,
+                          ).colorScheme.onPrimaryContainer,
+                        ),
                       ),
                     ),
-                  ),
-                  const Spacer(),
-                  IconButton(
-                    onPressed: () => Navigator.pop(context),
-                    icon: const Icon(Icons.close),
-                    style: IconButton.styleFrom(
-                      backgroundColor: Colors.grey.shade100,
+                    const Spacer(),
+                    IconButton(
+                      onPressed: () => Navigator.pop(context),
+                      icon: const Icon(Icons.close),
+                      style: IconButton.styleFrom(
+                        backgroundColor: Colors.grey.shade100,
+                      ),
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 16),
-              Text(
-                record.activity,
-                style: const TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
+                  ],
                 ),
-              ),
-              const SizedBox(height: 16),
-              const Divider(),
-              const SizedBox(height: 12),
-              _detailRow(Icons.timer_outlined, '時間', record.duration),
-              if (record.location != null)
-                _detailRow(Icons.place_outlined, '場所', record.location!),
-              if (record.comment != null)
+                const SizedBox(height: 16),
+                Text(
+                  record.activity,
+                  style: const TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Divider(),
+                const SizedBox(height: 12),
+                _detailRow(Icons.timer_outlined, '時間', record.duration),
+                if (record.location != null)
+                  _detailRow(Icons.place_outlined, '場所', record.location!),
+                if (record.comment != null)
+                  _detailRow(Icons.comment_outlined, 'コメント', record.comment!),
                 _detailRow(
-                    Icons.comment_outlined, 'コメント', record.comment!),
-              _detailRow(
-                Icons.fitness_center,
-                '${record.date.month}月の運動回数',
-                '${record.monthlyCount}回',
-              ),
-              const SizedBox(height: 20),
-              Row(
-                children: [
-                  Expanded(
-                    child: ElevatedButton.icon(
-                      onPressed: () {
-                        Navigator.pop(context, DetailDialogResult.edit);
-                      },
-                      icon: const Icon(Icons.edit),
-                      label: const Text('編集'),
-                      style: ElevatedButton.styleFrom(
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
+                  Icons.fitness_center,
+                  '${record.date.month}月の運動回数',
+                  '${record.monthlyCount}回',
+                ),
+                const SizedBox(height: 20),
+                Row(
+                  children: [
+                    Expanded(
+                      child: ElevatedButton.icon(
+                        onPressed: () {
+                          Navigator.pop(context, DetailDialogResult.edit);
+                        },
+                        icon: const Icon(Icons.edit),
+                        label: const Text('編集'),
+                        style: ElevatedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 8),
-                  Expanded(
-                    child: ElevatedButton.icon(
-                      onPressed: () => _confirmAndDelete(context, record),
-                      icon: const Icon(Icons.delete),
-                      label: const Text('削除'),
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Colors.red,
-                        foregroundColor: Colors.white,
-                        padding: const EdgeInsets.symmetric(vertical: 12),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(12),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: ElevatedButton.icon(
+                        onPressed: () => _confirmAndDelete(context, record),
+                        icon: const Icon(Icons.delete),
+                        label: const Text('削除'),
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.red,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(vertical: 12),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(12),
+                          ),
                         ),
                       ),
                     ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 8),
-              SizedBox(
-                width: double.infinity,
-                child: ElevatedButton.icon(
-                  onPressed: () {
-                    final message = record.toSlackMessage();
-                    Clipboard.setData(ClipboardData(text: message));
-                    Navigator.pop(context);
-                    scaffoldMessenger.showSnackBar(
-                      const SnackBar(
-                          content: Text('Slackメッセージをコピーしました！')),
-                    );
-                  },
-                  icon: const Icon(Icons.copy),
-                  label: const Text('Slackメッセージをコピー'),
-                  style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(vertical: 12),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    onPressed: () {
+                      final message = record.toSlackMessage();
+                      Clipboard.setData(ClipboardData(text: message));
+                      Navigator.pop(context);
+                      scaffoldMessenger.showSnackBar(
+                        const SnackBar(content: Text('Slackメッセージをコピーしました！')),
+                      );
+                    },
+                    icon: const Icon(Icons.copy),
+                    label: const Text('Slackメッセージをコピー'),
+                    style: ElevatedButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(vertical: 12),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(12),
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
-      ),
       ),
     ),
   );
 }
 
-Future<void> _confirmAndDelete(BuildContext context, TrainingRecord record) async {
+Future<void> _confirmAndDelete(
+  BuildContext context,
+  TrainingRecord record,
+) async {
   final confirm = await showDialog<bool>(
     context: context,
     builder: (context) => AlertDialog(
@@ -154,10 +158,7 @@ Future<void> _confirmAndDelete(BuildContext context, TrainingRecord record) asyn
         ),
         TextButton(
           onPressed: () => Navigator.pop(context, true),
-          child: const Text(
-            '削除',
-            style: TextStyle(color: Colors.red),
-          ),
+          child: const Text('削除', style: TextStyle(color: Colors.red)),
         ),
       ],
     ),

--- a/lib/screens/training_record_form.dart
+++ b/lib/screens/training_record_form.dart
@@ -170,60 +170,60 @@ class _TrainingRecordFormState extends State<TrainingRecordForm> {
               child: Form(
                 key: _formKey,
                 child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  _buildDatePicker(),
-                  _buildLabeledField(
-                    label: '何をしたか',
-                    controller: _whatDidController,
-                    maxLines: 3,
-                    validator: (value) {
-                      if (value == null || value.trim().isEmpty) {
-                        return '何をしたかを入力してください';
-                      }
-                      return null;
-                    },
-                  ),
-                  _buildLabeledField(
-                    label: 'どれくらいの時間やったか',
-                    controller: _howLongController,
-                    validator: (value) {
-                      if (value == null || value.trim().isEmpty) {
-                        return 'どれくらいの時間やったかを入力してください';
-                      }
-                      return null;
-                    },
-                  ),
-                  _buildLabeledField(
-                    label: 'コメント',
-                    controller: _commentController,
-                    maxLines: 2,
-                  ),
-                  _buildLabeledField(
-                    label: 'どこでやったか',
-                    controller: _whereController,
-                  ),
-                  _buildLabeledField(
-                    label: '${_selectedDate.month}月の運動回数',
-                    controller: _countController,
-                    validator: (value) {
-                      if (value == null || value.trim().isEmpty) {
-                        return '運動回数を入力してください';
-                      }
-                      return null;
-                    },
-                  ),
-                  const SizedBox(height: 8),
-                  SizedBox(
-                    width: double.infinity,
-                    child: ElevatedButton(
-                      onPressed: _saveRecord,
-                      child: Text(_isEditing ? '更新' : '登録'),
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    _buildDatePicker(),
+                    _buildLabeledField(
+                      label: '何をしたか',
+                      controller: _whatDidController,
+                      maxLines: 3,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return '何をしたかを入力してください';
+                        }
+                        return null;
+                      },
                     ),
-                  ),
-                ],
+                    _buildLabeledField(
+                      label: 'どれくらいの時間やったか',
+                      controller: _howLongController,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'どれくらいの時間やったかを入力してください';
+                        }
+                        return null;
+                      },
+                    ),
+                    _buildLabeledField(
+                      label: 'コメント',
+                      controller: _commentController,
+                      maxLines: 2,
+                    ),
+                    _buildLabeledField(
+                      label: 'どこでやったか',
+                      controller: _whereController,
+                    ),
+                    _buildLabeledField(
+                      label: '${_selectedDate.month}月の運動回数',
+                      controller: _countController,
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return '運動回数を入力してください';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: 8),
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: _saveRecord,
+                        child: Text(_isEditing ? '更新' : '登録'),
+                      ),
+                    ),
+                  ],
+                ),
               ),
-            ),
             ),
           ),
         ),

--- a/lib/screens/training_record_list.dart
+++ b/lib/screens/training_record_list.dart
@@ -17,7 +17,8 @@ class TrainingRecordList extends StatefulWidget {
 }
 
 class _TrainingRecordListState extends State<TrainingRecordList> {
-  late final TrainingRepository _repository = widget.repositoryOverride ?? repository;
+  late final TrainingRepository _repository =
+      widget.repositoryOverride ?? repository;
   List<TrainingRecord> _records = [];
   bool _isLoading = true;
 
@@ -43,38 +44,43 @@ class _TrainingRecordListState extends State<TrainingRecordList> {
       body: _isLoading
           ? const Center(child: CircularProgressIndicator())
           : _records.isEmpty
-              ? const Center(
-                  child: Text(
-                    '記録がありません',
-                    style: TextStyle(fontSize: 16, color: Colors.grey),
-                  ),
-                )
-              : ListView.builder(
-                  padding: const EdgeInsets.all(16),
-                  itemCount: _records.length,
-                  itemBuilder: (context, index) {
-                    final record = _records[index];
-                    return TrainingRecordCard(
-                      record: record,
-                      onTap: () async {
-                        final dialogResult = await showRecordDetailDialog(context, record);
-                        if (dialogResult == DetailDialogResult.delete) {
-                          _loadRecords();
-                        } else if (dialogResult == DetailDialogResult.edit && context.mounted) {
-                          final formResult = await Navigator.push<bool>(
-                            context,
-                            MaterialPageRoute(
-                              builder: (context) => TrainingRecordForm(record: record),
-                            ),
-                          );
-                          if (formResult == true) {
-                            _loadRecords();
-                          }
-                        }
-                      },
+          ? const Center(
+              child: Text(
+                '記録がありません',
+                style: TextStyle(fontSize: 16, color: Colors.grey),
+              ),
+            )
+          : ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: _records.length,
+              itemBuilder: (context, index) {
+                final record = _records[index];
+                return TrainingRecordCard(
+                  record: record,
+                  onTap: () async {
+                    final dialogResult = await showRecordDetailDialog(
+                      context,
+                      record,
                     );
+                    if (dialogResult == DetailDialogResult.delete) {
+                      _loadRecords();
+                    } else if (dialogResult == DetailDialogResult.edit &&
+                        context.mounted) {
+                      final formResult = await Navigator.push<bool>(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) =>
+                              TrainingRecordForm(record: record),
+                        ),
+                      );
+                      if (formResult == true) {
+                        _loadRecords();
+                      }
+                    }
                   },
-                ),
+                );
+              },
+            ),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
           final result = await Navigator.push<bool>(

--- a/lib/utils/display_helpers.dart
+++ b/lib/utils/display_helpers.dart
@@ -1,10 +1,7 @@
 /// 改行区切りのアクティビティテキストを「 / 」区切りの1行に変換する。
 /// 空行は除外される。
 String formatActivityDisplay(String activity) {
-  return activity
-      .split('\n')
-      .where((l) => l.trim().isNotEmpty)
-      .join(' / ');
+  return activity.split('\n').where((l) => l.trim().isNotEmpty).join(' / ');
 }
 
 /// コメントを最大[maxLength]文字にプレビュー用に切り詰める。

--- a/test/repositories/training_repository_test.dart
+++ b/test/repositories/training_repository_test.dart
@@ -89,11 +89,14 @@ void main() {
 
     test('新しい日付順にソートされる', () async {
       await repository.saveRecord(
-          createRecord(id: 'old', date: DateTime(2024, 1, 1)));
+        createRecord(id: 'old', date: DateTime(2024, 1, 1)),
+      );
       await repository.saveRecord(
-          createRecord(id: 'new', date: DateTime(2024, 3, 1)));
+        createRecord(id: 'new', date: DateTime(2024, 3, 1)),
+      );
       await repository.saveRecord(
-          createRecord(id: 'mid', date: DateTime(2024, 2, 1)));
+        createRecord(id: 'mid', date: DateTime(2024, 2, 1)),
+      );
 
       final records = await repository.getAllRecords();
       expect(records.length, 3);
@@ -104,9 +107,11 @@ void main() {
 
     test('同じ日付のレコードが複数ある場合もエラーにならない', () async {
       await repository.saveRecord(
-          createRecord(id: 'a', date: DateTime(2024, 1, 1)));
+        createRecord(id: 'a', date: DateTime(2024, 1, 1)),
+      );
       await repository.saveRecord(
-          createRecord(id: 'b', date: DateTime(2024, 1, 1)));
+        createRecord(id: 'b', date: DateTime(2024, 1, 1)),
+      );
 
       final records = await repository.getAllRecords();
       expect(records.length, 2);
@@ -115,8 +120,7 @@ void main() {
 
   group('getRecordById', () {
     test('存在するIDでレコードを取得できる', () async {
-      await repository.saveRecord(
-          createRecord(id: 'target', activity: '筋トレ'));
+      await repository.saveRecord(createRecord(id: 'target', activity: '筋トレ'));
 
       final record = await repository.getRecordById('target');
       expect(record, isNotNull);
@@ -163,13 +167,17 @@ void main() {
   group('getRecordsByDateRange', () {
     setUp(() async {
       await repository.saveRecord(
-          createRecord(id: 'jan', date: DateTime(2024, 1, 15)));
+        createRecord(id: 'jan', date: DateTime(2024, 1, 15)),
+      );
       await repository.saveRecord(
-          createRecord(id: 'feb', date: DateTime(2024, 2, 15)));
+        createRecord(id: 'feb', date: DateTime(2024, 2, 15)),
+      );
       await repository.saveRecord(
-          createRecord(id: 'mar', date: DateTime(2024, 3, 15)));
+        createRecord(id: 'mar', date: DateTime(2024, 3, 15)),
+      );
       await repository.saveRecord(
-          createRecord(id: 'apr', date: DateTime(2024, 4, 15)));
+        createRecord(id: 'apr', date: DateTime(2024, 4, 15)),
+      );
     });
 
     test('範囲内のレコードのみ返される', () async {

--- a/test/screens/training_record_list_test.dart
+++ b/test/screens/training_record_list_test.dart
@@ -24,8 +24,7 @@ void main() {
 
   group('TrainingRecordList', () {
     testWidgets('レコードがない場合は空状態メッセージを表示する', (tester) async {
-      when(() => mockRepository.getAllRecords())
-          .thenAnswer((_) async => []);
+      when(() => mockRepository.getAllRecords()).thenAnswer((_) async => []);
 
       await tester.pumpWidget(buildTestWidget());
       // 初回pumpでFutureを解決
@@ -38,8 +37,9 @@ void main() {
     testWidgets('ローディング中はCircularProgressIndicatorを表示する', (tester) async {
       // Completerで解決しないFutureを作りローディング状態を維持
       final completer = Completer<List<TrainingRecord>>();
-      when(() => mockRepository.getAllRecords())
-          .thenAnswer((_) => completer.future);
+      when(
+        () => mockRepository.getAllRecords(),
+      ).thenAnswer((_) => completer.future);
 
       await tester.pumpWidget(buildTestWidget());
 
@@ -61,8 +61,9 @@ void main() {
           monthlyCount: 5,
         ),
       ];
-      when(() => mockRepository.getAllRecords())
-          .thenAnswer((_) async => records);
+      when(
+        () => mockRepository.getAllRecords(),
+      ).thenAnswer((_) async => records);
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pump();
@@ -88,8 +89,9 @@ void main() {
           monthlyCount: 5,
         ),
       ];
-      when(() => mockRepository.getAllRecords())
-          .thenAnswer((_) async => records);
+      when(
+        () => mockRepository.getAllRecords(),
+      ).thenAnswer((_) async => records);
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pump();
@@ -99,8 +101,7 @@ void main() {
     });
 
     testWidgets('FABが表示される', (tester) async {
-      when(() => mockRepository.getAllRecords())
-          .thenAnswer((_) async => []);
+      when(() => mockRepository.getAllRecords()).thenAnswer((_) async => []);
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pump();
@@ -110,8 +111,7 @@ void main() {
     });
 
     testWidgets('AppBarにタイトルが表示される', (tester) async {
-      when(() => mockRepository.getAllRecords())
-          .thenAnswer((_) async => []);
+      when(() => mockRepository.getAllRecords()).thenAnswer((_) async => []);
 
       await tester.pumpWidget(buildTestWidget());
       await tester.pump();

--- a/test/utils/display_helpers_test.dart
+++ b/test/utils/display_helpers_test.dart
@@ -28,10 +28,7 @@ void main() {
     });
 
     test('3行以上の結合', () {
-      expect(
-        formatActivityDisplay('ランニング\n筋トレ\nストレッチ'),
-        'ランニング / 筋トレ / ストレッチ',
-      );
+      expect(formatActivityDisplay('ランニング\n筋トレ\nストレッチ'), 'ランニング / 筋トレ / ストレッチ');
     });
   });
 


### PR DESCRIPTION
## Summary

- `analysis_options.yaml` に `formatter: page_width: 80` を明示的に設定
- `.claude/settings.json` を新規作成し、Claude Code Hooks（PostToolUse）で `.dart` ファイル編集時に `dart format` を自動実行
- `.github/workflows/deploy.yml` に `dart format --output=none --set-exit-if-changed .` のチェックステップを追加（Analyze の前に配置）
- 既存コード全体に `dart format` を適用（10ファイル、主に80文字超の行の折り返し）

## 多層防御の構成

| 層 | 手段 | 役割 |
|---|---|---|
| 第1層 | Claude Code Hooks（PostToolUse） | 編集時の即座のフォーマット（format-on-save相当） |
| 第2層 | CLAUDE.mdの指示（既存） | そもそもフォーマット準拠のコードを書くよう指示 |
| 第3層 | CIフォーマットチェック | 最終防衛線（PRで強制） |

## Test plan

- [x] `dart format --output=none --set-exit-if-changed .` → 0 changed
- [x] `flutter analyze` → No issues found
- [x] `flutter test` → 68テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)