### PR TITLE
fix(deps): cap hive_ce_generator below 1.11.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
-  hive_ce_generator: ^1.6.1
+  hive_ce_generator: ">=1.6.1 <1.11.2"
   build_runner: ^2.4.6
   mocktail: ^1.0.5
 


### PR DESCRIPTION
hive_ce_generator 1.11.2 pulls in analyzer ^12.0.0, which requires
meta ^1.18.0. The flutter_test SDK dependency pins meta to 1.16.0,
so pub version resolution fails (see PR #27 CI failure). Capping the
constraint keeps resolution on hive_ce_generator <=1.11.1, whose
analyzer ^10.0.0 requirement is compatible with the SDK's meta pin.